### PR TITLE
Fixes for nougat (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Seven Sqaure
+Seven Square
 ============
 
 Android screencast wroted in QT. There is one in java? forget it from now on.

--- a/src/adbfb.cpp
+++ b/src/adbfb.cpp
@@ -287,17 +287,18 @@ void ADBDevice::probeDevice(void)
     probeDeviceHasSysLCDBL();
 }
 
-/* FIXME: We'd better use Android's API level to probe the os revision */
 int ADBDevice::probeDeviceOSType(void)
 {
     AdbExecutor adb;
     int os = ANDROID_ICS;
 
     adb.addArg("shell");
-    adb.addArg("input");
+    adb.addArg("getprop");
+    adb.addArg("ro.build.version.sdk");
+
     adb.run();
 
-    if (adb.outputHas("swipe")) {
+    if (adb.output.simplified().toInt() >= 16) {
         os = ANDROID_JB;
     }
     //qDebug() << "OS type:" << os << adb.output;
@@ -362,7 +363,7 @@ void ADBDevice::probeInputDevices(void)
     QStringList args;
     QList<QByteArray> lines;
 
-    args << "shell" << "ls" << QString(SYS_INPUT_DIR) + "input*";
+    args << "shell" << "ls -d" << QString(SYS_INPUT_DIR) + "input*";
     adb.run(args);
 
     if (! adb.exitSuccess()) {

--- a/src/adbfb.h
+++ b/src/adbfb.h
@@ -193,7 +193,7 @@ public:
 #define SYS_INPUT_DIR       "/sys/class/input/"
 #define SYS_INPUT_INDEX_OFFSET 22
 
-#define EV_IS_TOUCHSCREEN(ev) (ev == 0x0B) // EV_SYN | EV_KEY | EV_ABS
+#define EV_IS_TOUCHSCREEN(ev) ((ev & (1 <<EV_SYN)) && (ev & (1 << EV_ABS)) && (ev & (1 << EV_KEY)))
 #define EV_IS_KEY(ev)	      ((ev == 0x03) || ((ev & (1 <<EV_KEY)) && (ev & (1 << EV_SW) || ev & (1 << EV_MSC))))
 #define EV_IS_MOUSE(ev)	      (ev == 0x17) // EV_SYN | EV_KEY | EV_REL | EV_MSC
 


### PR DESCRIPTION
* Separately check event bits to determine if it's a touchscreen

Some touchscreen devices might report more events than just EV_SYN,
EV_ABS and EV_KEY. In this case, the input device would not be
detected as a touchscreen.

* Use the Android API level to determine the OS revision

* Use '-d' option when listing input devices

Newer versions of Android will list the contents of the input*
directories, instead of just the directory names, unless the '-d'
option is used.

* Fix application name